### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Azure Subscription Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-subscription/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-subscription/azurerm/)
 
 This Overlay terraform module can manage an Alias for a Subscription - which adds an Alias to an existing Subscription, allowing it to be managed in Terraform or create a new Subscription with a new Alias (Optional) under a Enrollment or Microsoft Customer Account.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 # Azure Subscription Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-subscription/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-subscription/azurerm/)
 
 This Overlay terraform module can manage an Alias for a Subscription - which adds an Alias to an existing Subscription, allowing it to be managed in Terraform or create a new Subscription with a new Alias (Optional) under a Enrollment or Microsoft Customer Account.
 

--- a/versions.tf
+++ b/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replace the `azurenoops/azurenoopsutils` Terraform provider with `POps-Rox/popsrox-utils` and update all `azurenoops` org references in documentation.

## Changes
- `versions.tf`: renamed provider key `azurenoopsutils` → `popsrox-utils`; updated source `azurenoops/azurenoopsutils` → `POps-Rox/popsrox-utils`
- `README.md`: updated TF Registry badge URL from `azurenoops` to `POps-Rox`
- `docs/index.md`: updated TF Registry badge URL from `azurenoops` to `POps-Rox`

## Testing
- `grep -rn "azurenoops" --include="*.tf" --include="*.md" .` returns no matches
- `terraform fmt -recursive` exits 0 with no changes

Closes #4