### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-subscription
+  name: terraform-az-overlays-subscription
   description: Terraform overlay module for Azure Subscription management
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-subscription
+    github.com/project-slug: POps-Rox/terraform-az-overlays-subscription
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-subscription
+    - url: https://github.com/POps-Rox/terraform-az-overlays-subscription
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/Commerical/create_alias/main.tf
+++ b/examples/Commerical/create_alias/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_alias_subscription" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-subscription"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-subscription"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/new_alias_and_sub_ea/main.tf
+++ b/examples/Commerical/new_alias_and_sub_ea/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_enrollment_subscription" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-subscription"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-subscription"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/new_alias_and_sub_mca/main.tf
+++ b/examples/Commerical/new_alias_and_sub_mca/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_mca_subscription" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-subscription"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-subscription"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/new_alias_and_sub_mpa/main.tf
+++ b/examples/Commerical/new_alias_and_sub_mpa/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_mpa_subscription" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-subscription"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-subscription"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/create_alias/main.tf
+++ b/examples/Government/create_alias/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_alias_subscription" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-subscription"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-subscription"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/new_alias_and_sub_ea/main.tf
+++ b/examples/Government/new_alias_and_sub_ea/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_enrollment_subscription" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-subscription"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-subscription"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/new_alias_and_sub_mca/main.tf
+++ b/examples/Government/new_alias_and_sub_mca/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_mca_subscription" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-subscription"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-subscription"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/new_alias_and_sub_mpa/main.tf
+++ b/examples/Government/new_alias_and_sub_mpa/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_mpa_subscription" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-subscription"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-subscription"
   #version = "x.x.x"
   source = "../../.."
 


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.